### PR TITLE
convert line 309 from chr array to string array

### DIFF
--- a/steam_accumulator_separate.m
+++ b/steam_accumulator_separate.m
@@ -306,7 +306,7 @@ classdef steam_accumulator_separate < handle
             %dive power energy line into array of doubles
             powerEnergyLine2 = extractBefore(powerEnergyLine, '     % MW MWh');
             powerEnergySpaces = regexp(powerEnergyLine2, ' ');
-            powerEnergyStringArray = [extractBefore(powerEnergyLine2, powerEnergySpaces(1)) extractAfter(powerEnergyLine2, powerEnergySpaces(1))];
+            powerEnergyStringArray = [string(extractBefore(powerEnergyLine2, powerEnergySpaces(1))) string(extractAfter(powerEnergyLine2, powerEnergySpaces(1)))];
             powerEnergyDoubleArray = str2double(powerEnergyStringArray);   
             
             %divide cost line into array of doubles


### PR DESCRIPTION
I was getting the error below because the original command created an array of 1 character ['50375'].


*****
Index exceeds matrix dimensions.

Error in steam_accumulator_separate/revenue (line 335)
            Eref = powerEnergyDoubleArray(2); %reference energy

Error in RUN_SA_SEPARATE (line 74)
[netRevenue,CC,RC,RD,totalOM,totalCC]=acc.revenue(POWER_SA,ENERGY_SA,MAIN_POWER,MIN_LOAD,LTANK,life,interest,period,peakAmplitude,avgElecPrice,caseNumber,hotCyclesPerYear,warmCyclesPerYear,coldCyclesPerYear,var_om);